### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
 # 📃 goprove
 
 Inspect your project for the best practices listed in the [Go CheckList](https://github.com/matttproud/gochecklist).
-  
-  
+
 [![Stories in Ready](https://badge.waffle.io/karolgorecki/goprove.png?label=ready&title=Ready)](https://waffle.io/karolgorecki/goprove)
 ### Get Started
 
-    $ go get github.com/karolgorecki/goprove
+    $ go get github.com/karolgorecki/goprove/cmd/goprove
     $ goprove .
 
 ### Usage
 
 ```
 Usage:
-
-  goprove <directory>
-
-  # output as json
-  goprove -output=json <directory>
+  SIMPLE:
+  	goprove <directory>
+  WITH OUTPUT:
+  	goprove -output=<output: json or text> <directory>
+  WITH EXCLUDE:
+  	goprove -exclude=<tasks: separated by comma> <directory>
+Available tasks for exclude:
+  projectBuilds, isFormatted, hasLicense, isLinted, isVetted, hasReadme,
+  testPassing, isDirMatch, hasContributing, hasBenches, hasBlackboxTests
 ```
 
 ### License


### PR DESCRIPTION
- `go get` should point to the `cmd/goprove` package
- add a few examples
