### PR TITLE
Added structs annotation (json not supported)

### DIFF
--- a/cmd/goprove/main.go
+++ b/cmd/goprove/main.go
@@ -69,7 +69,8 @@ func printOutput(passed []map[string]interface{}, failed []map[string]interface{
 	case "json":
 		enc := json.NewEncoder(os.Stdout)
 		enc.Encode(struct {
-			Passed, Failed []map[string]interface{}
+			Passed []map[string]interface{} `json:"passed"`
+			Failed []map[string]interface{} `json:"failed"`
 		}{
 			passed, failed,
 		})

--- a/goprove.go
+++ b/goprove.go
@@ -22,9 +22,10 @@ var (
 type itemCategory byte
 
 type checkItem struct {
-	Name, Desc string
-	Category   itemCategory
-	fn         func() bool
+	Name     string       `json:"name"`
+	Desc     string       `json:"desc"`
+	Category itemCategory `json:"category"`
+	fn       func() bool
 }
 
 func (ci checkItem) run() (success bool) {

--- a/goprove.go
+++ b/goprove.go
@@ -22,9 +22,9 @@ var (
 type itemCategory byte
 
 type checkItem struct {
-	Name     string       `json:"name"`
-	Desc     string       `json:"desc"`
-	Category itemCategory `json:"category"`
+	Name     string       `structs:"name"`
+	Desc     string       `structs:"desc"`
+	Category itemCategory `structs:"category"`
 	fn       func() bool
 }
 


### PR DESCRIPTION
Use

``` go
type checkItem struct {
    Name     string       `structs:"name"`
    Desc     string       `structs:"desc"`
    Category itemCategory `structs:"category"`
    fn       func() bool
}
```

instead of

``` go
type checkItem struct {
    Name     string       `json:"name"`
    Desc     string       `json:"desc"`
    Category itemCategory `json:"category"`
    fn       func() bool
}
```
